### PR TITLE
Fix: AgentDefinitionService test setup

### DIFF
--- a/MaIN.InferPage.IntegrationTests/AgentUpdateTests.cs
+++ b/MaIN.InferPage.IntegrationTests/AgentUpdateTests.cs
@@ -1,4 +1,5 @@
 using MaIN.Core;
+using MaIN.Domain.Repositories;
 using MaIN.InferPage.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +28,11 @@ public class AgentUpdateTests
         await using var sp = services.BuildServiceProvider();
         sp.UseMaIN();
 
-        var svc = new AgentDefinitionService(sp.GetRequiredService<IHttpClientFactory>(), config);
+        var svc = new AgentDefinitionService(
+            sp.GetRequiredService<IAgentRepository>(),
+            sp.GetRequiredService<IChatRepository>(),
+            sp.GetRequiredService<IHttpClientFactory>(),
+            config);
 
         try
         {


### PR DESCRIPTION
AgentDefinitionService now requires repository dependencies for agent and chat data access. This change updates the InferPage integration test bootstrap to resolve IAgentRepository and IChatRepository before constructing the service, matching the current constructor contract.