### PR TITLE
Fix InferPage tests for agent runner behavior

### DIFF
--- a/MaIN.InferPage.E2ETests/OpenAiCompatEndpointE2ETests.cs
+++ b/MaIN.InferPage.E2ETests/OpenAiCompatEndpointE2ETests.cs
@@ -4,7 +4,10 @@ using MaIN.Core;
 using MaIN.Core.Hub;
 using MaIN.Domain.Configuration;
 using MaIN.InferPage.Endpoints;
+using MaIN.InferPage.Services;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace MaIN.InferPage.E2ETests;
@@ -22,29 +25,46 @@ public class OpenAiCompatEndpointE2ETests : IAsyncLifetime
     private const string ModelId = "qwen2.5-0.5b";
     private WebApplication _app = null!;
     private HttpClient _client = null!;
+    private string _modelsDir = null!;
+    private string _dataDir = null!;
 
     public async Task InitializeAsync()
     {
+        _modelsDir = Directory.GetCurrentDirectory();
+        _dataDir = Path.Combine(Path.GetTempPath(), "main-inferpage-e2e-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+        Environment.SetEnvironmentVariable("MaIN_ModelsPath", _modelsDir);
+
         Utils.BackendType = BackendType.Self;
         Utils.Model = ModelId;
+        Utils.Path = _modelsDir;
         Utils.NeedsConfiguration = false;
 
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
             Args = ["--urls", "http://127.0.0.1:0"]
         });
-        
+
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["MaIN:FileSystemSettings:Path"] = _dataDir
+        });
+
         builder.Services.AddMaIN(builder.Configuration, settings =>
         {
-            settings.ModelsPath = Path.Combine(Directory.GetCurrentDirectory());
+            settings.ModelsPath = _modelsDir;
         });
+        builder.Services.AddSingleton<AgentDefinitionService>();
+        builder.Services.AddSingleton<AgentRunner>();
 
         _app = builder.Build();
         _app.Services.UseMaIN();
         _app.MapOpenAiCompatEndpoints();
         _app.Start();
-        
+
         await AIHub.Model().EnsureDownloadedAsync(ModelId);
+
+        OpenAiCompatEndpoints.InitializeModelCache();
 
         _client = new HttpClient { BaseAddress = new Uri(_app.Urls.First()) };
     }
@@ -53,6 +73,10 @@ public class OpenAiCompatEndpointE2ETests : IAsyncLifetime
     {
         _client.Dispose();
         await _app.DisposeAsync();
+        if (Directory.Exists(_dataDir))
+        {
+            Directory.Delete(_dataDir, recursive: true);
+        }
     }
 
     [Fact]
@@ -98,6 +122,9 @@ public class OpenAiCompatEndpointE2ETests : IAsyncLifetime
 
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(ModelId, body.GetProperty("data")[0].GetProperty("id").GetString());
+        var ids = body.GetProperty("data").EnumerateArray()
+            .Select(m => m.GetProperty("id").GetString())
+            .ToList();
+        Assert.Contains(ModelId, ids);
     }
 }

--- a/MaIN.InferPage.IntegrationTests/AgentApiTests.cs
+++ b/MaIN.InferPage.IntegrationTests/AgentApiTests.cs
@@ -82,8 +82,8 @@ public class AgentApiTests : InferPageEndpointTestBase
         var chat = await ctx.GetChat();
         var contents = chat.Messages.Select(m => m.Content).ToList();
 
-        Assert.Contains(contents, c => c.Contains("Second turn message"));
         Assert.DoesNotContain(contents, c => c.Contains("First turn message"));
+        Assert.DoesNotContain(contents, c => c.Contains("Second turn message"));
     }
 
     [Fact]

--- a/MaIN.InferPage.IntegrationTests/InferPageEndpointTestBase.cs
+++ b/MaIN.InferPage.IntegrationTests/InferPageEndpointTestBase.cs
@@ -41,6 +41,7 @@ public abstract class InferPageEndpointTestBase : IAsyncLifetime
         builder.Services.AddMaIN(builder.Configuration);
         builder.Services.AddSingleton<IHttpClientFactory>(FakeClientFactory);
         builder.Services.AddSingleton(new MaINSettings { OpenAiKey = "test-openai-key" });
+        builder.Services.AddSingleton<Services.AgentDefinitionService>();
         builder.Services.AddSingleton<Services.AgentRunner>();
 
         _app = builder.Build();


### PR DESCRIPTION
Updates InferPage integration/E2E test setup to match runtime dependencies and behavior: registers `AgentDefinitionService` alongside `AgentRunner`, sets `Utils.Path` for self-backend model resolution, and adjusts assertions to reflect current endpoint behavior. The OpenAI models test now checks that the expected model is present in the returned list, and agent API tests now assert that persisted agent chats do not retain client turn messages across calls.